### PR TITLE
Don't display comment with bold or italics

### DIFF
--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -30,7 +30,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Developer Certificate of Origin](${input.getPathToDocument()}) before we can accept your contribution. You can sign the DCO by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
     let text = `**DCO Assistant Lite bot:** ${lineOne}
    - - -
-   ***${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}***
+   ${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}
    - - -
    `
 
@@ -72,7 +72,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement](${input.getPathToDocument()}) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
     let text = `**CLA Assistant Lite bot:** ${lineOne}
    - - -
-   ***${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}***
+   ${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}
    - - -
    `
 


### PR DESCRIPTION
We've frequently run into people getting confused by the instructions to post a comment with "the below format". The format is bold/italic, but the bot won't accept comments written in bold/italics - it has to be plaintext without any additional Markdown formatting.

<img width="919" alt="Screen Shot 2022-03-28 at 11 53 41" src="https://user-images.githubusercontent.com/1476544/160467207-f1a31721-0b50-4351-9543-96508cf7eb11.png">

This PR removes the bold/italics.