### PR TITLE
Add additional info to the "Could not update the JSON file" error message 

### DIFF
--- a/src/setupClaCheck.ts
+++ b/src/setupClaCheck.ts
@@ -52,7 +52,9 @@ export async function setupClaCheck() {
       )
     }
   } catch (err) {
-    core.setFailed(`Could not update the JSON file: ${err.message}`)
+    let extraInfo = '';
+    if (err.message.includes('Changes must be made through a pull request')) extraInfo = ' (The branch appears to be protected - please disable the protection)';
+    core.setFailed(`Could not update the JSON file: ${err.message}${extraInfo}`)
   }
 }
 


### PR DESCRIPTION
The error message is confusing when the branch is protected, so this pull request adds additional information.