### PR TITLE
Explicitly configure workflow permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a followup of #130. Helps to catch obscure failure when repository configures `GITHUB_TOKEN` workflow permissions to be more restrictive than required by the CLA workflow.