### PR TITLE
Reduce unnecessary mentions

### DIFF
--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -36,7 +36,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
 
     if (committersCount > 1 && committerMap && committerMap.signed && committerMap.notSigned) {
         text += `**${committerMap.signed.length}** out of **${committerMap.signed.length + committerMap.notSigned.length}** committers have signed the DCO.`
-        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: @${signedCommitter.name}` })
+        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: (${signedCommitter.name})[https://github.com/${signedCommitter.name}]` })
         committerMap.notSigned.forEach(unsignedCommitter => {
             text += `<br/>:x: @${unsignedCommitter.name}`
         })
@@ -78,7 +78,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
 
     if (committersCount > 1 && committerMap && committerMap.signed && committerMap.notSigned) {
         text += `**${committerMap.signed.length}** out of **${committerMap.signed.length + committerMap.notSigned.length}** committers have signed the CLA.`
-        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: @${signedCommitter.name}` })
+        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: (${signedCommitter.name})[https://github.com/${signedCommitter.name}]` })
         committerMap.notSigned.forEach(unsignedCommitter => {
             text += `<br/>:x: @${unsignedCommitter.name}`
         })


### PR DESCRIPTION
Hi there.
In the current code, both signed committers and unsigned committers will be mentioned when not all of the committers sign the CLA/DCO. This behavior brings a lot of unnecessary mentions for the signed committers. I think only unsigned committers should be mentioned.
In this PR. I replace the mentions to the signed committers with a link to their profile. Users can still click the link to access the users' profiles.