### PR TITLE
Move CLA/DCO bot name into subscript at end of comment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -592,10 +592,10 @@ function getComment() {
             //TODO: check the below regex
             // using a `string` true or false purposely as github action input cannot have a boolean value
             if ((0, getInputs_1.getUseDcoFlag)() === 'true') {
-                return response.data.find(comment => comment.body.match(/.*DCO Assistant Lite bot.*/));
+                return response.data.find(comment => comment.body.match(/.*DCO Assistant Lite bot.*/m));
             }
             else if ((0, getInputs_1.getUseDcoFlag)() === 'false') {
-                return response.data.find(comment => comment.body.match(/.*CLA Assistant Lite bot.*/));
+                return response.data.find(comment => comment.body.match(/.*CLA Assistant Lite bot.*/m));
             }
         }
         catch (error) {
@@ -670,7 +670,7 @@ exports.commentContent = commentContent;
 function dco(signed, committerMap) {
     if (signed) {
         const line1 = input.getCustomAllSignedPrComment() || `All contributors have signed the DCO  ✍️ ✅`;
-        const text = `****DCO Assistant Lite bot**** ${line1}`;
+        const text = `${line1}<br/><sub>Posted by the ****DCO Assistant Lite bot****.</sub>`;
         return text;
     }
     let committersCount = 1;
@@ -679,7 +679,7 @@ function dco(signed, committerMap) {
     }
     let you = committersCount > 1 ? `you all` : `you`;
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Developer Certificate of Origin](${input.getPathToDocument()}) before we can accept your contribution. You can sign the DCO by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you);
-    let text = `**DCO Assistant Lite bot:** ${lineOne}
+    let text = `${lineOne}
    - - -
    ${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}
    - - -
@@ -698,13 +698,13 @@ function dco(signed, committerMap) {
         text += `**${committerNames.join(", ")}** ${seem} not to be a GitHub user.`;
         text += ' You need a GitHub account to be able to sign the DCO. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>';
     }
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request</sub>';
+    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the ****DCO Assistant Lite bot****.</sub>';
     return text;
 }
 function cla(signed, committerMap) {
     if (signed) {
         const line1 = input.getCustomAllSignedPrComment() || `All contributors have signed the CLA  ✍️ ✅`;
-        const text = `****CLA Assistant Lite bot**** ${line1}`;
+        const text = `${line1}<br/><sub>Posted by the ****CLA Assistant Lite bot****.</sub>`;
         return text;
     }
     let committersCount = 1;
@@ -713,7 +713,7 @@ function cla(signed, committerMap) {
     }
     let you = committersCount > 1 ? `you all` : `you`;
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement](${input.getPathToDocument()}) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you);
-    let text = `**CLA Assistant Lite bot:** ${lineOne}
+    let text = `${lineOne}
    - - -
    ${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}
    - - -
@@ -732,7 +732,7 @@ function cla(signed, committerMap) {
         text += `**${committerNames.join(", ")}** ${seem} not to be a GitHub user.`;
         text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>';
     }
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request</sub>';
+    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the **CLA Assistant Lite bot**.</sub>';
     return text;
 }
 

--- a/src/pullrequest/pullRequestComment.ts
+++ b/src/pullrequest/pullRequestComment.ts
@@ -62,9 +62,9 @@ async function getComment() {
     //TODO: check the below regex
     // using a `string` true or false purposely as github action input cannot have a boolean value
     if (getUseDcoFlag() === 'true') {
-      return response.data.find(comment => comment.body.match(/.*DCO Assistant Lite bot.*/))
+      return response.data.find(comment => comment.body.match(/.*DCO Assistant Lite bot.*/m))
     } else if (getUseDcoFlag() === 'false') {
-      return response.data.find(comment => comment.body.match(/.*CLA Assistant Lite bot.*/))
+      return response.data.find(comment => comment.body.match(/.*CLA Assistant Lite bot.*/m))
     }
   } catch (error) {
     throw new Error(`Error occured when getting  all the comments of the pull request: ${error.message}`)

--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -16,7 +16,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
 
     if (signed) {
         const line1 = input.getCustomAllSignedPrComment() || `All contributors have signed the DCO  ✍️ ✅`
-        const text = `****DCO Assistant Lite bot**** ${line1}`
+        const text = `${line1}<br/><sub>Posted by the ****DCO Assistant Lite bot****.</sub>`
         return text
     }
     let committersCount = 1
@@ -28,7 +28,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
 
     let you = committersCount > 1 ? `you all` : `you`
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Developer Certificate of Origin](${input.getPathToDocument()}) before we can accept your contribution. You can sign the DCO by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
-    let text = `**DCO Assistant Lite bot:** ${lineOne}
+    let text = `${lineOne}
    - - -
    ${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}
    - - -
@@ -50,7 +50,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
         text += ' You need a GitHub account to be able to sign the DCO. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>'
     }
 
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request</sub>'
+    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the ****DCO Assistant Lite bot****.</sub>'
     return text
 }
 
@@ -58,7 +58,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
 
     if (signed) {
         const line1 = input.getCustomAllSignedPrComment() || `All contributors have signed the CLA  ✍️ ✅`
-        const text = `****CLA Assistant Lite bot**** ${line1}`
+        const text = `${line1}<br/><sub>Posted by the ****CLA Assistant Lite bot****.</sub>`
         return text
     }
     let committersCount = 1
@@ -70,7 +70,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
 
     let you = committersCount > 1 ? `you all` : `you`
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement](${input.getPathToDocument()}) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
-    let text = `**CLA Assistant Lite bot:** ${lineOne}
+    let text = `${lineOne}
    - - -
    ${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}
    - - -
@@ -92,6 +92,6 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
         text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>'
     }
 
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request</sub>'
+    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the **CLA Assistant Lite bot**.</sub>'
     return text
 }


### PR DESCRIPTION
The "**CLA Assistant Lite bot**" at the begin of every comment is a bit distracting IMHO. Not sure if this change is desired, but I moved it to the small subscript text at the end of the comment.