### PR TITLE
Update required GITHUB_TOKEN permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ on:
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: read
+  actions: write
   contents: write # this can be 'read' if the signatures are in remote repository
   pull-requests: write
-  statuses: read
+  statuses: write
 
 jobs:
   CLAAssistant:

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ on:
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: write
-  contents: write
+  actions: read
+  contents: write # this can be 'read' if the signatures are in remote repository
   pull-requests: write
-  statuses: write
+  statuses: read
 
 jobs:
   CLAAssistant:


### PR DESCRIPTION
`contents: read` should be enough when signatures are stored in a remote repository.

Tested here: https://github.com/pellared/test-cla/pull/1