### PR TITLE
Add an option to disable the "recheck" part of the comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This PAT should have repo scope and is only required if you have configured to s
 | `custom-pr-sign-comment`   | _optional_ | The signature to be committed in order to sign the CLA. | I have read the Developer Terms Document and I hereby accept the Terms |
 | `custom-allsigned-prcomment`   | _optional_ | pull request comment when everyone has signed | All Contributors have signed the CLA. |
 | `lock-pullrequest-aftermerge`   | _optional_ | Boolean input for locking the pull request after merging. Default is set to `true`.  It is highly recommended to lock the Pull Request after merging so that the Contributors won't be able to revoke their signature comments after merge | false |
+| `suggest-recheck`   | _optional_ | Boolean input for indicating if the action's comment should suggest that users comment `recheck`. Default is set to `true`. | false |
 
 ## Contributors
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   lock-pullrequest-aftermerge:
     description: "Will lock the pull request after merge so that the signature the contributors cannot revoke their signature comments after merge"
     default: "true"
+  suggest-recheck:
+    description: "Controls whether or not the action's comment should suggest that users comment `recheck`."
+    default: "true"
 runs:
   using: "node20"
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -698,7 +698,9 @@ function dco(signed, committerMap) {
         text += `**${committerNames.join(", ")}** ${seem} not to be a GitHub user.`;
         text += ' You need a GitHub account to be able to sign the DCO. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>';
     }
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the ****DCO Assistant Lite bot****.</sub>';
+    if (input.suggestRecheck() == 'true') {
+        text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the ****DCO Assistant Lite bot****.</sub>';
+    }
     return text;
 }
 function cla(signed, committerMap) {
@@ -1053,7 +1055,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.lockPullRequestAfterMerge = exports.getCustomPrSignComment = exports.getUseDcoFlag = exports.getCustomAllSignedPrComment = exports.getCustomNotSignedPrComment = exports.getCreateFileCommitMessage = exports.getSignedCommitMessage = exports.getEmptyCommitFlag = exports.getAllowListItem = exports.getBranch = exports.getPathToDocument = exports.getPathToSignatures = exports.getRemoteOrgName = exports.getRemoteRepoName = void 0;
+exports.suggestRecheck = exports.lockPullRequestAfterMerge = exports.getCustomPrSignComment = exports.getUseDcoFlag = exports.getCustomAllSignedPrComment = exports.getCustomNotSignedPrComment = exports.getCreateFileCommitMessage = exports.getSignedCommitMessage = exports.getEmptyCommitFlag = exports.getAllowListItem = exports.getBranch = exports.getPathToDocument = exports.getPathToSignatures = exports.getRemoteOrgName = exports.getRemoteRepoName = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const getRemoteRepoName = () => {
     return core.getInput('remote-repository-name', { required: false });
@@ -1087,7 +1089,8 @@ const getCustomPrSignComment = () => core.getInput('custom-pr-sign-comment', { r
 exports.getCustomPrSignComment = getCustomPrSignComment;
 const lockPullRequestAfterMerge = () => core.getInput('lock-pullrequest-aftermerge', { required: false });
 exports.lockPullRequestAfterMerge = lockPullRequestAfterMerge;
-
+const suggestRecheck = () => core.getInput('suggest-recheck', { required: false });
+exports.suggestRecheck = suggestRecheck;
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -657,6 +657,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commentContent = void 0;
 const input = __importStar(__nccwpck_require__(3611));
+const pr_sign_comment_1 = __nccwpck_require__(6718);
 function commentContent(signed, committerMap) {
     // using a `string` true or false purposely as github action input cannot have a boolean value
     if (input.getUseDcoFlag() == 'true') {
@@ -717,7 +718,7 @@ function cla(signed, committerMap) {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement](${input.getPathToDocument()}) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you);
     let text = `${lineOne}
    - - -
-   ${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}
+   ${(0, pr_sign_comment_1.getPrSignComment)()}
    - - -
    `;
     if (committersCount > 1 && committerMap && committerMap.signed && committerMap.notSigned) {
@@ -734,7 +735,9 @@ function cla(signed, committerMap) {
         text += `**${committerNames.join(", ")}** ${seem} not to be a GitHub user.`;
         text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>';
     }
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the **CLA Assistant Lite bot**.</sub>';
+    if (input.suggestRecheck() == 'true') {
+        text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the **CLA Assistant Lite bot**.</sub>';
+    }
     return text;
 }
 
@@ -1091,6 +1094,46 @@ const lockPullRequestAfterMerge = () => core.getInput('lock-pullrequest-aftermer
 exports.lockPullRequestAfterMerge = lockPullRequestAfterMerge;
 const suggestRecheck = () => core.getInput('suggest-recheck', { required: false });
 exports.suggestRecheck = suggestRecheck;
+
+
+/***/ }),
+
+/***/ 6718:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getPrSignComment = void 0;
+const input = __importStar(__nccwpck_require__(3611));
+function getPrSignComment() {
+    return input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA";
+}
+exports.getPrSignComment = getPrSignComment;
+
 
 /***/ }),
 

--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -51,7 +51,9 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
         text += ' You need a GitHub account to be able to sign the DCO. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>'
     }
 
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the ****DCO Assistant Lite bot****.</sub>'
+    if (input.suggestRecheck() == 'true') {
+        text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the ****DCO Assistant Lite bot****.</sub>'
+    }
     return text
 }
 
@@ -93,6 +95,8 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
         text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).<br/>'
     }
 
-    text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the **CLA Assistant Lite bot**.</sub>'
+    if (input.suggestRecheck() == 'true') {
+        text += '<sub>You can retrigger this bot by commenting **recheck** in this Pull Request. Posted by the **CLA Assistant Lite bot**.</sub>'
+    }
     return text
 }

--- a/src/shared/getInputs.ts
+++ b/src/shared/getInputs.ts
@@ -43,3 +43,6 @@ export const getCustomPrSignComment = (): string =>
 
 export const lockPullRequestAfterMerge = (): string =>
   core.getInput('lock-pullrequest-aftermerge', { required: false })
+
+export const suggestRecheck = (): string =>
+  core.getInput('suggest-recheck', { required: false })


### PR DESCRIPTION
We've found that due to the suggestion in the action's comment that users' comment "recheck" we've ended up with everyone commenting their agreement immediately followed by commenting recheck. Or, commenting both in the same comment. Therefore we'd like the option to disable the "recheck" suggestion.

Note: I have very little experience with GitHub action creation/contribution, if I've edited something I shouldn't have then please let me know, or conversely missed editing something I should have.

Prepared via: dev.github.com
Modeled mainly based on `lock-pullrequest-aftermerge` handling.