### PR TITLE
readme: fix invalid action tag in main snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@2.5.0
+        uses: contributor-assistant/github-action@v2.5.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
Current snippet in README is missing the "v" prefix when targeting the action version, resulting in an early failure when trying to open a pull request on a repository with the corresponding action freshly installed.

While at it, use the latest tag.