### PR TITLE
Fix markdown link in 'X out of Y contributors have signed' comment

### DIFF
--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -37,7 +37,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
 
     if (committersCount > 1 && committerMap && committerMap.signed && committerMap.notSigned) {
         text += `**${committerMap.signed.length}** out of **${committerMap.signed.length + committerMap.notSigned.length}** committers have signed the DCO.`
-        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: (${signedCommitter.name})[https://github.com/${signedCommitter.name}]` })
+        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: [${signedCommitter.name}](https://github.com/${signedCommitter.name})` })
         committerMap.notSigned.forEach(unsignedCommitter => {
             text += `<br/>:x: @${unsignedCommitter.name}`
         })
@@ -82,7 +82,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
 
     if (committersCount > 1 && committerMap && committerMap.signed && committerMap.notSigned) {
         text += `**${committerMap.signed.length}** out of **${committerMap.signed.length + committerMap.notSigned.length}** committers have signed the CLA.`
-        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: (${signedCommitter.name})[https://github.com/${signedCommitter.name}]` })
+        committerMap.signed.forEach(signedCommitter => { text += `<br/>:white_check_mark: [${signedCommitter.name}](https://github.com/${signedCommitter.name})` })
         committerMap.notSigned.forEach(unsignedCommitter => {
             text += `<br/>:x: @${unsignedCommitter.name}`
         })


### PR DESCRIPTION
Currently, links to usernames aren't rendered correctly:

<img width="594" alt="Screenshot 2025-05-29 at 10 19 16" src="https://github.com/user-attachments/assets/27af2f8a-5f5c-40b2-a786-7252118b1b5a" />
